### PR TITLE
make lshw test work regardless of hostname

### DIFF
--- a/hwtest.sh
+++ b/hwtest.sh
@@ -35,7 +35,7 @@ else
 fi
 
 echo -n -e "# Hardware list..."
-if lshw -disable usb -disable scsi |grep -v size|grep -v serial| grep -v physical |grep -v configuration| diff - /usr/lib/hwtest/lshw_ref.txt >>log.txt; then
+if lshw -disable usb -disable scsi -sanitize |grep -v size|grep -v serial| grep -v physical |grep -v configuration| diff - /usr/lib/hwtest/lshw_ref.txt >>log.txt; then
   TESTS_PASSED=$((TESTS_PASSED + 1))
 	echo "# Hardware list...OK";
 else

--- a/lshw_ref.txt
+++ b/lshw_ref.txt
@@ -1,4 +1,4 @@
-chip
+computer
     description: Computer
     product: NextThing C.H.I.P.
     width: 32 bits


### PR DESCRIPTION
If a hostname other than "chip" is specified in a custom buildroot configuration, the lshw test will fail. The -sanitize option for lshw is designed to (quoting the manpage) "remove potentially sensitive information from output". In this case it changes the hostname label to "computer".