### PR TITLE
Fix math and register issues in /usr/bin/battery.sh

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -58,8 +58,8 @@ echo "CHARGE_CTL2="$CHARGE_CTL2
 
 ################################
 #read battery voltage	79h, 78h	0 mV -> 000h,	1.1 mV/bit	FFFh -> 4.5045 V
-BAT_VOLT_LSB=$(i2cget -y -f 0 0x34 0x79)
 BAT_VOLT_MSB=$(i2cget -y -f 0 0x34 0x78)
+BAT_VOLT_LSB=$(i2cget -y -f 0 0x34 0x79)
 
 #echo $BAT_VOLT_MSB $BAT_VOLT_LSB
 
@@ -70,8 +70,8 @@ echo "Battery voltage = "$BAT_VOLT"mV"
 
 ###################
 #read Battery Discharge Current	7Ah, 7Bh	0 mV -> 000h,	0.5 mA/bit	FFFh -> 4.095 V
-BAT_IDISCHG_LSB=$(i2cget -y -f 0 0x34 0x7B)
 BAT_IDISCHG_MSB=$(i2cget -y -f 0 0x34 0x7A)
+BAT_IDISCHG_LSB=$(i2cget -y -f 0 0x34 0x7B)
 
 #echo $BAT_IDISCHG_MSB $BAT_IDISCHG_LSB
 
@@ -82,8 +82,8 @@ echo "Battery discharge current = "$BAT_IDISCHG"mA"
 
 ###################
 #read Battery Charge Current	7Ch, 7Dh	0 mV -> 000h,	0.5 mA/bit	FFFh -> 4.095 V
-BAT_ICHG_LSB=$(i2cget -y -f 0 0x34 0x7D)
 BAT_ICHG_MSB=$(i2cget -y -f 0 0x34 0x7C)
+BAT_ICHG_LSB=$(i2cget -y -f 0 0x34 0x7D)
 
 #echo $BAT_ICHG_MSB $BAT_ICHG_LSB
 

--- a/battery.sh
+++ b/battery.sh
@@ -62,32 +62,37 @@ BAT_VOLT_MSB=$(i2cget -y -f 0 0x34 0x78)
 BAT_VOLT_LSB=$(i2cget -y -f 0 0x34 0x79)
 
 #echo $BAT_VOLT_MSB $BAT_VOLT_LSB
-
-BAT_BIN=$(( $(($BAT_VOLT_MSB << 4)) | $(($(($BAT_VOLT_LSB & 0xF0)) >> 4)) ))
+# bash math -- converts hex to decimal so `bc` won't complain later...
+# MSB is 8 bits, LSB is lower 4 bits
+BAT_BIN=$(( $(($BAT_VOLT_MSB << 4)) | $(($(($BAT_VOLT_LSB & 0x0F)) )) ))
 
 BAT_VOLT=$(echo "($BAT_BIN*1.1)"|bc)
 echo "Battery voltage = "$BAT_VOLT"mV"
 
 ###################
-#read Battery Discharge Current	7Ah, 7Bh	0 mV -> 000h,	0.5 mA/bit	FFFh -> 4.095 V
-BAT_IDISCHG_MSB=$(i2cget -y -f 0 0x34 0x7A)
-BAT_IDISCHG_LSB=$(i2cget -y -f 0 0x34 0x7B)
+#read Battery Discharge Current	7Ch, 7Dh	0 mV -> 000h,	0.5 mA/bit	1FFFh -> 1800 mA
+#AXP209 datasheet is wrong, discharge current is in registers 7Ch 7Dh
+#13 bits
+BAT_IDISCHG_MSB=$(i2cget -y -f 0 0x34 0x7C)
+BAT_IDISCHG_LSB=$(i2cget -y -f 0 0x34 0x7D)
 
 #echo $BAT_IDISCHG_MSB $BAT_IDISCHG_LSB
 
-BAT_IDISCHG_BIN=$(( $(($BAT_IDISCHG_MSB << 4)) | $(($(($BAT_IDISCHG_LSB & 0xF0)) >> 4)) ))
+BAT_IDISCHG_BIN=$(( $(($BAT_IDISCHG_MSB << 5)) | $(($(($BAT_IDISCHG_LSB & 0x1F)) )) ))
 
 BAT_IDISCHG=$(echo "($BAT_IDISCHG_BIN*0.5)"|bc)
 echo "Battery discharge current = "$BAT_IDISCHG"mA"
 
 ###################
-#read Battery Charge Current	7Ch, 7Dh	0 mV -> 000h,	0.5 mA/bit	FFFh -> 4.095 V
-BAT_ICHG_MSB=$(i2cget -y -f 0 0x34 0x7C)
-BAT_ICHG_LSB=$(i2cget -y -f 0 0x34 0x7D)
+#read Battery Charge Current	7Ah, 7Bh	0 mV -> 000h,	0.5 mA/bit	FFFh -> 1800 mA
+#AXP209 datasheet is wrong, charge current is in registers 7Ah 7Bh
+#(12 bits)
+BAT_ICHG_MSB=$(i2cget -y -f 0 0x34 0x7A)
+BAT_ICHG_LSB=$(i2cget -y -f 0 0x34 0x7B)
 
 #echo $BAT_ICHG_MSB $BAT_ICHG_LSB
 
-BAT_ICHG_BIN=$(( $(($BAT_ICHG_MSB << 4)) | $(($(($BAT_ICHG_LSB & 0xF0)) >> 4)) ))
+BAT_ICHG_BIN=$(( $(($BAT_ICHG_MSB << 4)) | $(($(($BAT_ICHG_LSB & 0x0F)) )) ))
 
 BAT_ICHG=$(echo "($BAT_ICHG_BIN*0.5)"|bc)
 echo "Battery charge current = "$BAT_ICHG"mA"


### PR DESCRIPTION
https://bbs.nextthing.co/t/usr-bin-battery-sh-got-it-backwards/1492

1. The AXP209 datasheet has the wrong registers for charge/discharge current.
2. Read multibyte values MSB first.
3. The battery.sh script was expecting the lsb value in the higher bits but it is in the lower bits.
4. The battery.sh script was expecting both charge and discharge to be 12 bits but the discharge value is actually 13 bits.