### PR TITLE
Update battery.sh for users without TS pin

### DIFF
--- a/chip-hwtest/bin/battery.sh
+++ b/chip-hwtest/bin/battery.sh
@@ -15,7 +15,8 @@
 #######################################################################
 
 # force ADC enable for battery voltage and current
-i2cset -y -f 0 0x34 0x82 0xC3
+i2cset -y -f -m 0x80 0 0x34 0x82 0xff
+i2cset -y -f -m 0x40 0 0x34 0x82 0xff
 
 ################################
 #read Power status register @00h
@@ -116,5 +117,3 @@ BAT_GAUGE_HEX=$(i2cget -y -f 0 0x34 0xb9)
 # bash math -- converts hex to decimal so `bc` won't complain later...
 # MSB is 8 bits, LSB is lower 4 bits
 BAT_GAUGE_DEC=$(($BAT_GAUGE_HEX))
-
-


### PR DESCRIPTION
User with TS pin could not use the battery.sh script without having to manually reset the value of register @82h.
The -m option of i2cset creates a mask for enabling ADC battery voltage and current only and will prevent other parameters such as TS pin from being changed.